### PR TITLE
feat: make learning interface mobile responsive

### DIFF
--- a/lessons/introduction-to-smartpy/08/08.mdx
+++ b/lessons/introduction-to-smartpy/08/08.mdx
@@ -51,8 +51,15 @@ Complete the attack and defense functions and upgrade attack and defense of your
 
 1) Add other parameter `params` in `attack` and `defense` functions,
 
-2) Add `attack` points in the state variable `attack` using `self.data.attack += params.attack` in `attack` function,
+2) Add `attack` points in the state variable `attack` using `attack` function
+```python 
+self.data.attack += params.attack
+```
 
-3) Add `defense` points in the state variable `defense` using `self.data.defense += params.defense` in `defense` function,
+3) Add `defense` points in the state variable `defense` using `defense` function
+
+```python
+self.data.defense += params.defense
+```
 
 

--- a/lessons/introduction-to-smartpy/11/11.mdx
+++ b/lessons/introduction-to-smartpy/11/11.mdx
@@ -48,13 +48,17 @@ editor:
 Maps are data structures that store key-value pairs. As a result, they enable smart contracts to create valuable associations between related information.
 
 Maps in SmartPy can be declared in the following manner:
-`sp.TMap:  e.g. {'A': 65, 'B': 66, 'C'; 67}`
+```python
+sp.TMap:  e.g. {'A': 65, 'B': 66, 'C'; 67}
+```
 
 sp.map(l = …, tkey = …, tvalue = …): Defines a map of (optional) elements in l with optional key type tkey and optional value type tvalue.
 
 or either by
 
-`sp.TBigMap: e.g. {'A': 65, 'B': 66, 'C'; 67}`
+```python
+sp.TBigMap: e.g. {'A': 65, 'B': 66, 'C'; 67}
+```
 
 sp.big_map(l = …, tkey = …, tvalue = …): Defines a big_map of (optional) elements in l with optional key type tkey and optional value type tvalue.
 
@@ -78,8 +82,13 @@ Mapping will be used to point your tezos wallet address with your character.
 
 3) Inside the function, assign the `stat` variable to the `sender's` using player `mapping` 
 
-   `self.data.player[params.sender] = self.data.stat` 
+```python
+self.data.player[params.sender] = self.data.stat
+``` 
    
 4) Inside the function, assign name to player's plant's name
-    `self.data.player[params.sender].name = params.name`
+
+```python
+self.data.player[params.sender].name = params.name
+```
 which will take one string parameter `name` which will be name of your plant.

--- a/lessons/introduction-to-smartpy/15/15.mdx
+++ b/lessons/introduction-to-smartpy/15/15.mdx
@@ -86,7 +86,10 @@ To overcome this, you will be using `sp.verify()` statement.
 1) Remove if/else statment from the previous code,
 
 2) Include `sp.verify()` statement to check the condition instead,
-    `sp.verify(~ self.data.player.contains(sp.sender), 
-          "User already has a plant")`
+
+```python
+sp.verify(~ self.data.player.contains(sp.sender), 
+"User already has a plant")
+```
 
 3) Create a callable function `endGame` that will verify the health of the player with a message "You are alive!!!". If health of the player is 0, change `is_alive` to `False`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4642,6 +4642,11 @@
         }
       }
     },
+    "css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA="
+    },
     "css-select": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
@@ -9499,6 +9504,11 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
     },
+    "hyphenate-style-name": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
+      "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -11373,6 +11383,14 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
       "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q=="
+    },
+    "matchmediaquery": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.3.1.tgz",
+      "integrity": "sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==",
+      "requires": {
+        "css-mediaquery": "^0.1.2"
+      }
     },
     "md5": {
       "version": "2.2.1",
@@ -14465,6 +14483,17 @@
         "scheduler": "^0.18.0"
       }
     },
+    "react-responsive": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-8.0.3.tgz",
+      "integrity": "sha512-F9VXyLao7O8XHXbLjQbIr4+mC6Zr0RDTwNjd7ixTmYEAyKyNanBkLkFchNaMZgszoSK6PgSs/3m/QDWw33/gpg==",
+      "requires": {
+        "hyphenate-style-name": "^1.0.0",
+        "matchmediaquery": "^0.3.0",
+        "prop-types": "^15.6.1",
+        "shallow-equal": "^1.1.0"
+      }
+    },
     "react-side-effect": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.2.0.tgz",
@@ -15556,6 +15585,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/shallow-compare/-/shallow-compare-1.2.2.tgz",
       "integrity": "sha512-LUMFi+RppPlrHzbqmFnINTrazo0lPNwhcgzuAXVVcfy/mqPDrQmHAyz5bvV0gDAuRFrk804V0HpQ6u9sZ0tBeg=="
+    },
+    "shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "shallowequal": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-helmet": "^5.2.1",
-    "react-icons": "^3.9.0"
+    "react-icons": "^3.9.0",
+    "react-responsive": "^8.0.3"
   },
   "devDependencies": {
     "@types/node": "^12.12.31",

--- a/src/templates/chapter.js
+++ b/src/templates/chapter.js
@@ -200,16 +200,16 @@ const ChapterTemplate = ({ data: { mdx: chapter } }) => {
                     </div>
                   ) : (
                     <div
-                      class="checking"
                       style={{
                         padding: 10,
                         height: '200px',
                         overflowY: 'auto',
                       }}
                     >
-                      {validation.error.map(errorMessage => {
+                      {validation.error.map((errorMessage, index) => {
                         return (
                           <p
+                            key={index}
                             style={{
                               fontFamily: 'Inconsolata',
                               color: '#d0454c',

--- a/src/templates/chapter.js
+++ b/src/templates/chapter.js
@@ -32,11 +32,6 @@ export const query = graphql`
   }
 `;
 
-export const EditorResponsiveView = () => {
-  const MobileView = window.innerWidth < 768;
-  return MobileView ? `calc(100vh - 130px)` : `calc(100vh - (210px + 40px))`;
-};
-
 const ChapterTemplate = ({ data: { mdx: chapter } }) => {
   const chapterList = useChapters();
   const [index] = useState(() => {
@@ -62,11 +57,9 @@ const ChapterTemplate = ({ data: { mdx: chapter } }) => {
   );
   const [showOutput, setShowOutput] = useState(false);
   const [buttonClicked, setButtonClicked] = useState(false);
-  var [editorHeight, setEditorHeight] = useState('');
-
-  useEffect(() => {
-    setEditorHeight(EditorResponsiveView);
-  }, []);
+  var [editorHeight, setEditorHeight] = useState(
+    `calc(100vh - (210px + 40px))`,
+  );
 
   useEffect(() => {
     monaco

--- a/src/templates/chapter.js
+++ b/src/templates/chapter.js
@@ -62,7 +62,12 @@ const ChapterTemplate = ({ data: { mdx: chapter } }) => {
   );
   const [showOutput, setShowOutput] = useState(false);
   const [buttonClicked, setButtonClicked] = useState(false);
-  var [editorHeight, setEditorHeight] = useState(EditorResponsiveView);
+  var [editorHeight, setEditorHeight] = useState('');
+
+  useEffect(() => {
+    setEditorHeight(EditorResponsiveView);
+  }, []);
+
   useEffect(() => {
     monaco
       .init()

--- a/src/templates/chapter.js
+++ b/src/templates/chapter.js
@@ -32,6 +32,11 @@ export const query = graphql`
   }
 `;
 
+export const EditorResponsiveView = () => {
+  const MobileView = window.innerWidth < 768;
+  return MobileView ? `calc(100vh - 130px)` : `calc(100vh - (210px + 40px))`;
+};
+
 const ChapterTemplate = ({ data: { mdx: chapter } }) => {
   const chapterList = useChapters();
   const [index] = useState(() => {
@@ -57,9 +62,7 @@ const ChapterTemplate = ({ data: { mdx: chapter } }) => {
   );
   const [showOutput, setShowOutput] = useState(false);
   const [buttonClicked, setButtonClicked] = useState(false);
-  var [editorHeight, setEditorHeight] = useState(
-    `calc(100vh - (210px + 40px))`,
-  );
+  var [editorHeight, setEditorHeight] = useState(EditorResponsiveView);
   useEffect(() => {
     monaco
       .init()
@@ -94,8 +97,7 @@ const ChapterTemplate = ({ data: { mdx: chapter } }) => {
       // cleanup;
     };
   }, []);
-  console.log('Data body', validation);
-  console.log('SHOWOUTPUT', showOutput);
+
   return (
     <Layout>
       <Container>

--- a/src/templates/chapter.js
+++ b/src/templates/chapter.js
@@ -57,7 +57,9 @@ const ChapterTemplate = ({ data: { mdx: chapter } }) => {
   );
   const [showOutput, setShowOutput] = useState(false);
   const [buttonClicked, setButtonClicked] = useState(false);
-  var [editorHeight, setEditorHeight] = useState(`calc(100vh - (210px + 40px))`);
+  var [editorHeight, setEditorHeight] = useState(
+    `calc(100vh - (210px + 40px))`,
+  );
   useEffect(() => {
     monaco
       .init()
@@ -128,9 +130,7 @@ const ChapterTemplate = ({ data: { mdx: chapter } }) => {
         >
           <ControlledEditor
             height={`${editorHeight}`}
-            // height={`100%`}
-            width={`calc(100vw - (100vw / 2.4))`}
-            marWidth={`calc(100vw - (100vw / 2.4))`}
+            marWidth={`calc(100vw)`}
             value={editorInputValue}
             onChange={(_, value) => {
               setEditorInputValue(value);
@@ -149,74 +149,86 @@ const ChapterTemplate = ({ data: { mdx: chapter } }) => {
               wordWrap: true,
             }}
           />
-          {
-            buttonClicked ?
-              showOutput ? (
-                <div>
-                  <Output>
-                    <div>output</div>
-                  </Output>
-                  <DiffEditor
-                    height="200px"
-                    original={showOutput ? chapter.frontmatter.editor.answer : 'MODIFIED'}
-                    modified={showOutput ? editorInputValue : 'MODIFIED'}
-                    language="python"
-                    theme="myCustomTheme"
-                    options={{
-                      lineNumbers: false,
-                      scrollBeyondLastLine: true,
-                      minimap: { enabled: false },
-                      scrollbar: { vertical: 'hidden', verticalScrollbarSize: 0 },
-                      folding: false,
-                      readOnly: true,
-                      fontSize: 18,
-                      fontFamily: 'Inconsolata',
-                      renderSideBySide: false,
-                      wordWrap: true,
-                    }}
-                  />
-                  
-                </div>
-              ) : (
-                  <div>
-                    <Output>
-                      <div>output</div>
-                    </Output>
-                    <div style={{ height: "200px", background: '#1B3738', color: '#fff' }}>
-                      {validation.success ? (
-                        <div style={{ fontFamily: 'Inconsolata', padding: 10 }}>
-                          <p style={{ color: '#18b77e', paddingBottom: 5 }}>
-                            <span> > </span>Great, you got it right!
-                  </p>
-                          <p style={{ color: '#18b77e' }}>
-                            <span> > </span>Click 'next >' to continue.
-                  </p>
-                        </div>
-                      ) : (
-                          <div class="checking" style={{ padding: 10, height: "200px", overflowY: 'auto'}}>
-                            {validation.error.map(errorMessage => {
-                              return (
-                                <p
-                                  style={{
-                                    fontFamily: 'Inconsolata',
-                                    color: '#d0454c',
-                                    paddingBottom: 5,
-                                  }}
-                                >
-                                  <span> {errorMessage ? '>' : ''} </span>
-                                  {errorMessage}
-                                </p>
-                              );
-                            })}
-                          </div>
-                        )}
+          {buttonClicked ? (
+            showOutput ? (
+              <div>
+                <Output>
+                  <div>output</div>
+                </Output>
+                <DiffEditor
+                  height="200px"
+                  original={
+                    showOutput ? chapter.frontmatter.editor.answer : 'MODIFIED'
+                  }
+                  modified={showOutput ? editorInputValue : 'MODIFIED'}
+                  language="python"
+                  theme="myCustomTheme"
+                  options={{
+                    lineNumbers: false,
+                    scrollBeyondLastLine: true,
+                    minimap: { enabled: false },
+                    scrollbar: { vertical: 'hidden', verticalScrollbarSize: 0 },
+                    folding: false,
+                    readOnly: true,
+                    fontSize: 18,
+                    fontFamily: 'Inconsolata',
+                    renderSideBySide: false,
+                    wordWrap: true,
+                  }}
+                />
+              </div>
+            ) : (
+              <div>
+                <Output>
+                  <div>output</div>
+                </Output>
+                <div
+                  style={{
+                    height: '200px',
+                    background: '#1B3738',
+                    color: '#fff',
+                  }}
+                >
+                  {validation.success ? (
+                    <div style={{ fontFamily: 'Inconsolata', padding: 10 }}>
+                      <p style={{ color: '#18b77e', paddingBottom: 5 }}>
+                        <span> > </span>Great, you got it right!
+                      </p>
+                      <p style={{ color: '#18b77e' }}>
+                        <span> > </span>Click 'next >' to continue.
+                      </p>
                     </div>
-                  </div>
-                )
-
-              : console.log("No Output")
-          }
-
+                  ) : (
+                    <div
+                      class="checking"
+                      style={{
+                        padding: 10,
+                        height: '200px',
+                        overflowY: 'auto',
+                      }}
+                    >
+                      {validation.error.map(errorMessage => {
+                        return (
+                          <p
+                            style={{
+                              fontFamily: 'Inconsolata',
+                              color: '#d0454c',
+                              paddingBottom: 5,
+                            }}
+                          >
+                            <span> {errorMessage ? '>' : ''} </span>
+                            {errorMessage}
+                          </p>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )
+          ) : (
+            console.log('No Output')
+          )}
         </ChapterEditor>
         <ChapterFooter
           chapter={chapter.frontmatter.chapter}

--- a/src/templates/chapter.styled.js
+++ b/src/templates/chapter.styled.js
@@ -8,7 +8,18 @@ export const Container = styled.div`
     'content editor editor editor'
     'content option option option'
     'footer footer footer footer';
+
+  @media only screen and (max-width: 767px) {
+    grid-template-areas:
+      'header '
+      'content'
+      'contractFile'
+      'editor'
+      'option'
+      'footer';
+  }
 `;
+
 export const Output = styled.div`
   height: 40px;
   background: #112425;

--- a/src/templates/components/ChapterContent/styled.tsx
+++ b/src/templates/components/ChapterContent/styled.tsx
@@ -3,8 +3,11 @@ import styled from '@emotion/styled';
 export const Content = styled.div`
   grid-area: content;
   overflow-y: auto;
-  height: calc(100vh - 140px);
-  width: calc(((100vw) / 2.4));
+
+  @media only screen and (min-width: 768px) {
+    height: calc(100vh - 140px);
+    width: calc(((100vw) / 2.4));
+  }
 `;
 
 export const ContentHeader = styled.div`

--- a/src/templates/components/ChapterEditor/index.tsx
+++ b/src/templates/components/ChapterEditor/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { TiTick } from 'react-icons/ti';
 import { AiOutlineQuestion } from 'react-icons/ai';
 import { checkCode } from '../../../utils/compiler';
@@ -36,11 +36,6 @@ function ChapterEditor({
   updateValidation,
   editorInputValue,
 }: Props) {
-  const [editorHeight, setResponsiveEditorHeight] = useState('');
-  useEffect(() => {
-    setResponsiveEditorHeight(EditorResponsiveView);
-  }, []);
-
   return (
     <>
       <ContractFile>
@@ -52,7 +47,7 @@ function ChapterEditor({
           onClick={() => {
             setShowOutput(true);
             setButtonClicked(true);
-            setEditorHeight(editorHeight);
+            setEditorHeight(`calc(100vh - (250px + 200px + 40px))`);
           }}
         >
           <AiOutlineQuestion /> <span>Show Answer</span>
@@ -61,7 +56,7 @@ function ChapterEditor({
           onClick={() => {
             setShowOutput(false);
             setButtonClicked(true);
-            setEditorHeight(editorHeight);
+            setEditorHeight(`calc(100vh - (250px + 200px + 40px))`);
             const result = checkCode(editorInputValue, chapterIndex.current);
             // console.log('result', result);
             updateValidation(result);

--- a/src/templates/components/ChapterEditor/index.tsx
+++ b/src/templates/components/ChapterEditor/index.tsx
@@ -10,6 +10,8 @@ import {
   CheckAnswerButton,
 } from './styled';
 
+import { EditorResponsiveView } from '../../chapter';
+
 interface Props {
   children: React.ReactNode;
   setShowOutput(input: boolean): void;
@@ -45,22 +47,22 @@ function ChapterEditor({
           onClick={() => {
             setShowOutput(true);
             setButtonClicked(true);
-            setEditorHeight(`calc(100vh - (250px + 200px + 40px))`);
+            setEditorHeight(EditorResponsiveView);
           }}
         >
-          <AiOutlineQuestion /> Show Answer
+          <AiOutlineQuestion /> <span>Show Answer</span>
         </ShowAnswerButton>
         <CheckAnswerButton
           onClick={() => {
             setShowOutput(false);
             setButtonClicked(true);
-            setEditorHeight(`calc(100vh - (250px + 200px + 40px))`);
+            setEditorHeight(EditorResponsiveView);
             const result = checkCode(editorInputValue, chapterIndex.current);
             // console.log('result', result);
             updateValidation(result);
           }}
         >
-          <TiTick /> Check
+          <TiTick /> <span>Check</span>
         </CheckAnswerButton>
       </Option>
     </>

--- a/src/templates/components/ChapterEditor/index.tsx
+++ b/src/templates/components/ChapterEditor/index.tsx
@@ -9,8 +9,7 @@ import {
   ShowAnswerButton,
   CheckAnswerButton,
 } from './styled';
-
-import { EditorResponsiveView } from '../../chapter';
+import { useMediaQuery } from 'react-responsive';
 
 interface Props {
   children: React.ReactNode;
@@ -36,6 +35,8 @@ function ChapterEditor({
   updateValidation,
   editorInputValue,
 }: Props) {
+  const isMobile = useMediaQuery({ query: '(max-width: 767px)' });
+
   return (
     <>
       <ContractFile>
@@ -47,7 +48,13 @@ function ChapterEditor({
           onClick={() => {
             setShowOutput(true);
             setButtonClicked(true);
-            setEditorHeight(`calc(100vh - (250px + 200px + 40px))`);
+            setEditorHeight(
+              `${
+                isMobile
+                  ? `calc(100vh - (130px)) `
+                  : `calc(100vh - (250px + 200px + 40px))`
+              }`,
+            );
           }}
         >
           <AiOutlineQuestion /> <span>Show Answer</span>
@@ -56,7 +63,13 @@ function ChapterEditor({
           onClick={() => {
             setShowOutput(false);
             setButtonClicked(true);
-            setEditorHeight(`calc(100vh - (250px + 200px + 40px))`);
+            setEditorHeight(
+              `${
+                isMobile
+                  ? `calc(100vh - (130px)) `
+                  : `calc(100vh - (250px + 200px + 40px))`
+              }`,
+            );
             const result = checkCode(editorInputValue, chapterIndex.current);
             // console.log('result', result);
             updateValidation(result);

--- a/src/templates/components/ChapterEditor/index.tsx
+++ b/src/templates/components/ChapterEditor/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { TiTick } from 'react-icons/ti';
 import { AiOutlineQuestion } from 'react-icons/ai';
 import { checkCode } from '../../../utils/compiler';
@@ -36,6 +36,11 @@ function ChapterEditor({
   updateValidation,
   editorInputValue,
 }: Props) {
+  const [editorHeight, setResponsiveEditorHeight] = useState('');
+  useEffect(() => {
+    setResponsiveEditorHeight(EditorResponsiveView);
+  }, []);
+
   return (
     <>
       <ContractFile>
@@ -47,7 +52,7 @@ function ChapterEditor({
           onClick={() => {
             setShowOutput(true);
             setButtonClicked(true);
-            setEditorHeight(EditorResponsiveView);
+            setEditorHeight(editorHeight);
           }}
         >
           <AiOutlineQuestion /> <span>Show Answer</span>
@@ -56,7 +61,7 @@ function ChapterEditor({
           onClick={() => {
             setShowOutput(false);
             setButtonClicked(true);
-            setEditorHeight(EditorResponsiveView);
+            setEditorHeight(editorHeight);
             const result = checkCode(editorInputValue, chapterIndex.current);
             // console.log('result', result);
             updateValidation(result);

--- a/src/templates/components/ChapterEditor/styled.tsx
+++ b/src/templates/components/ChapterEditor/styled.tsx
@@ -52,6 +52,14 @@ export const CheckAnswerButton = styled.button`
     background: #66cca7;
     color: #fff;
   }
+
+  @media only screen and (max-width: 767px) {
+    span {
+      display: none;
+    }
+
+    padding: 1rem 2rem;
+  }
 `;
 export const ShowAnswerButton = styled.button`
   height: 60px;
@@ -69,5 +77,12 @@ export const ShowAnswerButton = styled.button`
   :hover {
     background: #436061;
     color: #fff;
+  }
+
+  @media only screen and (max-width: 767px) {
+    span {
+      display: none;
+    }
+    padding: 1rem 2rem;
   }
 `;

--- a/src/templates/components/ChapterEditor/styled.tsx
+++ b/src/templates/components/ChapterEditor/styled.tsx
@@ -4,7 +4,10 @@ export const ContractFile = styled.div`
   grid-area: contractFile;
   background: #112425;
   height: 50px;
-  width: calc(100vw - (100vw / 2.4));
+
+  @media only screen and (min-width: 768px) {
+    width: calc(100vw - (100vw / 2.4));
+  }
 
   > p {
     background: #1b3738;
@@ -26,9 +29,11 @@ export const Option = styled.div`
   grid-area: option;
   background: #112425;
   height: 60px;
-  width: calc(100vw - (100vw / 2.4));
   display: flex;
   justify-content: flex-end;
+  @media only screen and (min-width: 768px) {
+    width: calc(100vw - (100vw / 2.4));
+  }
 `;
 export const CheckAnswerButton = styled.button`
   height: 60px;

--- a/src/templates/components/ChapterFooter/styled.tsx
+++ b/src/templates/components/ChapterFooter/styled.tsx
@@ -51,6 +51,12 @@ export const PrevLink = styled(Link)`
     display: inline-block;
     vertical-align: middle;
   }
+
+  @media only screen and (max-width: 767px) {
+    span {
+      display: none;
+    }
+  }
 `;
 
 export const ContentIndex = styled.span`
@@ -69,5 +75,11 @@ export const NextLink = styled(Link)`
   > svg {
     display: inline-block;
     vertical-align: middle;
+  }
+
+  @media only screen and (max-width: 767px) {
+    span {
+      display: none;
+    }
   }
 `;

--- a/src/templates/components/ChapterHeader/styled.tsx
+++ b/src/templates/components/ChapterHeader/styled.tsx
@@ -36,6 +36,10 @@ export const LessonTitle = styled.h1`
   text-align: center;
   line-height: 27px;
   color: #ffffff;
+
+  @media only screen and (max-width: 767px) {
+    display: none;
+  }
 `;
 
 export const HelpButton = styled.button`

--- a/src/templates/components/MenuSlider/styled.tsx
+++ b/src/templates/components/MenuSlider/styled.tsx
@@ -18,6 +18,10 @@ export const SideDrawer = styled.div`
     list-style-type: none;
     padding: 0;
   }
+
+  @media only screen and (max-width: 767px) {
+    width: 100vw;
+  }
 `;
 
 export const Backdrop = styled.div`

--- a/src/templates/prism-custom.css
+++ b/src/templates/prism-custom.css
@@ -7,8 +7,8 @@
   border-radius: 0.3em;
   margin: 0.5em 0;
   padding: 1em;
-  overflow-y: hidden;
-  overflow-x: hidden;
+  overflow-y: auto;
+  overflow-x: auto;
 }
 
 /**
@@ -22,8 +22,8 @@
   background-color: transparent;
   margin: 0;
   padding: 0;
-  overflow-y: hidden;
-  overflow-x: hidden;
+  overflow-y: auto;
+  overflow-x: auto;
   float: left; /* 1 */
   min-width: 100%; /* 2 */
 }


### PR DESCRIPTION
**What does this PR do?**
Make learning interface mobile responsive

**Description of Task to be completed?**
Make learning interface content and editor stack on each other in case viewport width < 768px
When in mobile view

-  Remove lessons header 
- only show icon for button action

**How should this be manually tested?**
check the preview link generated by netlify build

**Any background context you want to provide?**

**Screenshots(optional)**
If applicable, add screenshots to help to explain the problem/solution.

**Additional context(optional)**
Add any other context if any.
